### PR TITLE
Enhanced README example task configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ The plugin is not especially configurable, but each task can be configured to lo
 analyzeClassesDependencies {
   justWarn = true
 }
+
+analyzeTestClassesDependencies {
+  justWarn = true
+}
 ```
 
 # Version 1.1


### PR DESCRIPTION
Added the "test class dependencies" to the example task configuration to make it more clear that both would need to be configured (and easier for future users to copy/paste).

There is also one slightly inaccurate related statement in the readme, but I'm not sure how best to rephrase it.  "Each task can be configured to log a warning about dependency issues" is not quite accurate, as only the "analyzeClassesDependencies" and "analyzeTestClassesDependencies" tasks can be configured thusly; "analyzeDependencies" cannot.