### PR TITLE
Added support for Gradle 4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,38 +49,44 @@ publishing {
   }
 }
 
-if (this.hasProperty('bintrayUser') && this.hasProperty('bintrayApiKey')) bintray {
-  user = bintrayUser
-  key = bintrayApiKey
-  publications = ['mavenJava']
-  pkg {
-    repo = 'maven'
-    name = project.name
-    desc = 'Dependency analysis plugin for gradle'
-    websiteUrl = 'https://github.com/wfhartford/gradle-dependency-analyze'
-    issueTrackerUrl = 'https://github.com/wfhartford/gradle-dependency-analyze/issues'
-    vcsUrl = 'https://github.com/wfhartford/gradle-dependency-analyze.git'
-  }
-}
-
-if (this.hasProperty('jfrogUser') && this.hasProperty('jfrogPassword')) artifactory {
-  contextUrl = 'http://oss.jfrog.org/artifactory'
-  publish {
-    repository {
-      repoKey = 'oss-snapshot-local'
-      username = jfrogUser
-      password = jfrogPassword
-      maven = true
-    }
-    defaults {
-      publications ('mavenJava')
+if (this.hasProperty('bintrayUser') && this.hasProperty('bintrayApiKey')) {
+  bintray {
+    user = bintrayUser
+    key = bintrayApiKey
+    publications = ['mavenJava']
+    pkg {
+      repo = 'maven'
+      name = project.name
+      desc = 'Dependency analysis plugin for gradle'
+      websiteUrl = 'https://github.com/wfhartford/gradle-dependency-analyze'
+      issueTrackerUrl = 'https://github.com/wfhartford/gradle-dependency-analyze/issues'
+      vcsUrl = 'https://github.com/wfhartford/gradle-dependency-analyze.git'
     }
   }
 }
 
-task javaVersionCheck() << {
-  if (JavaVersion.current() != JavaVersion.VERSION_1_6) {
-    throw new GradleException('Build must be run on Java 6')
+if (this.hasProperty('jfrogUser') && this.hasProperty('jfrogPassword')) {
+  artifactory {
+    contextUrl = 'http://oss.jfrog.org/artifactory'
+    publish {
+      repository {
+        repoKey = 'oss-snapshot-local'
+        username = jfrogUser
+        password = jfrogPassword
+        maven = true
+      }
+      defaults {
+        publications('mavenJava')
+      }
+    }
+  }
+}
+
+task javaVersionCheck() {
+  doLast {
+    if (JavaVersion.current() != JavaVersion.VERSION_1_6) {
+      throw new GradleException('Build must be run on Java 6')
+    }
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -20,7 +20,8 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
         allowedToDeclare = [
             project.configurations.permitUnusedDeclared
         ]
-        classesDir = project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).output.classesDir
+        def output = project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).output
+        classesDirs = output.hasProperty('classesDirs') ? output.classesDirs : [output.classesDir]
       }
       project.analyzeDependencies.dependsOn('analyzeClassesDependencies')
     }
@@ -37,7 +38,8 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
         allowedToDeclare = [
             project.configurations.permitTestUnusedDeclared
         ]
-        classesDir = project.sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).output.classesDir
+        def output = project.sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).output
+        classesDirs = output.hasProperty('classesDirs') ? output.classesDirs : [output.classesDir]
       }
       project.analyzeDependencies.dependsOn('analyzeTestClassesDependencies')
     }

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -7,17 +7,21 @@ import org.gradle.api.tasks.TaskAction
 
 class AnalyzeDependenciesTask extends DefaultTask {
   boolean justWarn
-  List<Configuration> require;
-  List<Configuration> allowedToUse;
-  List<Configuration> allowedToDeclare;
-  File classesDir;
+  List<Configuration> require
+  List<Configuration> allowedToUse
+  List<Configuration> allowedToDeclare
+  Iterable<File> classesDirs
+
+  void setClassesDir(File classesDir) {
+    this.classesDirs = [classesDir]
+  }
 
   @TaskAction
   def action() {
-    project.logger.info "Analyzing dependencies of $classesDir for [require: $require, allowedToUse: $allowedToUse, " +
+    project.logger.info "Analyzing dependencies of $classesDirs for [require: $require, allowedToUse: $allowedToUse, " +
         "allowedToDeclare: $allowedToDeclare]"
     ProjectDependencyAnalysis analysis =
-        new ProjectDependencyResolver(project.logger, require, allowedToUse, allowedToDeclare, classesDir)
+        new ProjectDependencyResolver(project.logger, require, allowedToUse, allowedToDeclare, classesDirs)
             .analyzeDependencies()
     StringBuffer buffer = new StringBuffer()
     ['usedUndeclaredArtifacts', 'unusedDeclaredArtifacts'].each {section ->


### PR DESCRIPTION
Gradle 4.0 added a classes directory for each compile task/JVM language.  This requires scanning possibly several classes directories.

Support remains for gradle 2 & 3 and Java version 6 and up.