### PR TITLE
Use gradle task output cache instead of internal static cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ analyzeTestClassesDependencies {
 }
 ```
 
+# Version 1.2
+Version 1.2 of this plugin introduces a couple significant changes.
+
+* For multi project builds, the plugin must now be applied to the root project. If it has not been applied to the root project, the build will fail with the message `Dependency analysis plugin must also be applied to the root project`.
+* The plugin will no longer fail to apply if the java plugin has not been applied. Applying this plugin to a project without the java plugin will have no effect.
+* The plugin no longer caches caches dependency information in a static cache which would persist across executions when the gradle daemon was in use. It now caches dependency information in the root project. This represents a small performance penalty but avoids a potential issue if a dependency file is modified, and a potential memory leak if the path of dependency files changes regularly.
+* The tasks now produce output files at `$buildDir/dependency-analyse/$taskName`. This contains the exception message if the task causes the build to fail, or is empty if the task does not cause the build to fail.
+* The tasks now specify inputs and outputs allowing gradle to consider a task up-to-date if nothing has changed.
+* The tasks allows caching of outputs on gradle versions which support the task output cache. This allows the task work to be skipped even on clean builds if an appropriate cached result exists.
+
 # Version 1.1
 Version 1.1 of this plugin introduced a couple significant changes.
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,22 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'ca.cutterslade.gradle:gradle-dependency-analyze:1.1.1'
+    classpath 'ca.cutterslade.gradle:gradle-dependency-analyze:1.2.0'
   }
 }
 
 apply plugin: 'java'
-// Dependency analysis plugin must be applied after the java plugin.
 apply plugin: 'ca.cutterslade.analyze'
+```
+
+When applying this plugin to a multi-project build, it should be applied the root project as well as all sub-projects for which dependency analysis is needed. A common pattern is to apply this plugin to all projects and the java plugin to only the sub-projects:
+```gradls
+allprojects {
+  apply plugin: 'ca.cutterslade.analyze'
+}
+subprojects {
+  apply plugin: 'java'
+}
 ```
 # Tasks
 This plugin will add three tasks to your project: `analyzeClassesDependencies`, `analyzeTestClassesDependencies`, and `analyzeDependencies`.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Version 1.2 of this plugin introduces a couple significant changes.
 * The tasks now produce output files at `$buildDir/dependency-analyse/$taskName`. This contains the exception message if the task causes the build to fail, or is empty if the task does not cause the build to fail.
 * The tasks now specify inputs and outputs allowing gradle to consider a task up-to-date if nothing has changed.
 * The tasks allows caching of outputs on gradle versions which support the task output cache. This allows the task work to be skipped even on clean builds if an appropriate cached result exists.
+* Tasks will now appear in the listing produced by `gradle tasks` under the Verification group.
+
+## Migration from 1.1
+Migrating from version 1.1 to version 1.2 of the plugin should be very simple. Most users will not have to make any changes, users with multi-project builds will have to ensure that the plugin is applied to the root project. This can be accomplished by applying the plugin in the `allprojects {}` block.
 
 # Version 1.1
 Version 1.1 of this plugin introduced a couple significant changes.

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'ca.cutterslade.gradle'
-version = '1.1.2-SNAPSHOT'
+version = '1.2.0-SNAPSHOT'
 
 repositories {
   jcenter()

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -4,45 +4,52 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSet
 
+import java.util.concurrent.ConcurrentHashMap
+
 class AnalyzeDependenciesPlugin implements Plugin<Project> {
   @Override
   void apply(final Project project) {
-    project.configurations.create('permitUnusedDeclared')
-    project.configurations.create('permitTestUnusedDeclared')
-    project.task('analyzeDependencies')
-    if (project.tasks['classes']) {
-      project.task(dependsOn: 'classes', type: AnalyzeDependenciesTask, 'analyzeClassesDependencies') {
-        require = [
-            project.configurations.compile,
-            project.configurations.findByName('compileOnly'),
-            project.configurations.findByName('provided')
-        ]
-        allowedToDeclare = [
-            project.configurations.permitUnusedDeclared
-        ]
-        def output = project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).output
-        classesDirs = output.hasProperty('classesDirs') ? output.classesDirs : [output.classesDir]
-      }
-      project.analyzeDependencies.dependsOn('analyzeClassesDependencies')
+    if (project.rootProject == project) {
+      project.rootProject.extensions.add(ProjectDependencyResolver.CACHE_NAME, new ConcurrentHashMap<>())
     }
-    if (project.tasks['testClasses']) {
-      project.task(dependsOn: 'testClasses', type: AnalyzeDependenciesTask, 'analyzeTestClassesDependencies') {
-        require = [
-            project.configurations.testCompile,
-            project.configurations.findByName('testCompileOnly')
-        ]
-        allowedToUse = [
-            project.configurations.compile,
-            project.configurations.findByName('provided')
-        ]
-        allowedToDeclare = [
-            project.configurations.permitTestUnusedDeclared
-        ]
-        def output = project.sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).output
-        classesDirs = output.hasProperty('classesDirs') ? output.classesDirs : [output.classesDir]
+    if (project.plugins.hasPlugin('java')) {
+      project.configurations.create('permitUnusedDeclared')
+      project.configurations.create('permitTestUnusedDeclared')
+      project.task('analyzeDependencies')
+      if (project.tasks['classes']) {
+        project.task(dependsOn: 'classes', type: AnalyzeDependenciesTask, 'analyzeClassesDependencies') {
+          require = [
+              project.configurations.compile,
+              project.configurations.findByName('compileOnly'),
+              project.configurations.findByName('provided')
+          ]
+          allowedToDeclare = [
+              project.configurations.permitUnusedDeclared
+          ]
+          def output = project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).output
+          classesDirs = output.hasProperty('classesDirs') ? output.classesDirs : project.files(output.classesDir)
+        }
+        project.analyzeDependencies.dependsOn('analyzeClassesDependencies')
       }
-      project.analyzeDependencies.dependsOn('analyzeTestClassesDependencies')
+      if (project.tasks['testClasses']) {
+        project.task(dependsOn: 'testClasses', type: AnalyzeDependenciesTask, 'analyzeTestClassesDependencies') {
+          require = [
+              project.configurations.testCompile,
+              project.configurations.findByName('testCompileOnly')
+          ]
+          allowedToUse = [
+              project.configurations.compile,
+              project.configurations.findByName('provided')
+          ]
+          allowedToDeclare = [
+              project.configurations.permitTestUnusedDeclared
+          ]
+          def output = project.sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).output
+          classesDirs = output.hasProperty('classesDirs') ? output.classesDirs : project.files(output.classesDir)
+        }
+        project.analyzeDependencies.dependsOn('analyzeTestClassesDependencies')
+      }
+      project.check.dependsOn('analyzeDependencies')
     }
-    project.check.dependsOn('analyzeDependencies')
   }
 }

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -4,7 +4,6 @@ import org.apache.maven.shared.dependency.analyzer.ProjectDependencyAnalysis
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
-import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -3,17 +3,35 @@ package ca.cutterslade.gradle.analyze
 import org.apache.maven.shared.dependency.analyzer.ProjectDependencyAnalysis
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.FileCollection
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
+import java.lang.reflect.Method
+
 class AnalyzeDependenciesTask extends DefaultTask {
-  boolean justWarn
-  List<Configuration> require
-  List<Configuration> allowedToUse
-  List<Configuration> allowedToDeclare
-  Iterable<File> classesDirs
+  @Input
+  boolean justWarn = false
+  List<Configuration> require = []
+  List<Configuration> allowedToUse = []
+  List<Configuration> allowedToDeclare = []
+  @InputFiles
+  FileCollection classesDirs = project.files()
+  @OutputFile
+  File outputFile = project.file("$project.buildDir/dependency-analyze/result")
+
+  AnalyzeDependenciesTask() {
+    def methods = outputs.class.getMethods().grep {Method m -> m.name == 'cacheIf'}
+    if (methods) {
+      outputs.cacheIf({true})
+    }
+  }
 
   void setClassesDir(File classesDir) {
-    this.classesDirs = [classesDir]
+    this.classesDirs = project.files(classesDir)
   }
 
   @TaskAction
@@ -21,7 +39,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
     project.logger.info "Analyzing dependencies of $classesDirs for [require: $require, allowedToUse: $allowedToUse, " +
         "allowedToDeclare: $allowedToDeclare]"
     ProjectDependencyAnalysis analysis =
-        new ProjectDependencyResolver(project.logger, require, allowedToUse, allowedToDeclare, classesDirs)
+        new ProjectDependencyResolver(project, require, allowedToUse, allowedToDeclare, classesDirs)
             .analyzeDependencies()
     StringBuffer buffer = new StringBuffer()
     ['usedUndeclaredArtifacts', 'unusedDeclaredArtifacts'].each {section ->
@@ -33,6 +51,8 @@ class AnalyzeDependenciesTask extends DefaultTask {
         }
       }
     }
+    outputFile.parentFile.mkdirs()
+    outputFile.text = buffer.toString()
     if (buffer) {
       def message = "Dependency analysis found issues.\n$buffer"
       if (justWarn) {
@@ -42,5 +62,48 @@ class AnalyzeDependenciesTask extends DefaultTask {
         throw new DependencyAnalysisException(message)
       }
     }
+  }
+
+  @InputFiles
+  FileCollection getAllArtifacts() {
+    project.files({
+      def files = ProjectDependencyResolver.removeNulls(
+          ProjectDependencyResolver.removeNulls(require)
+              *.resolvedConfiguration
+              *.firstLevelModuleDependencies
+              *.allModuleArtifacts
+              *.file.flatten() as Set<File>
+      )
+      project.logger.info "All Artifact Files: $files"
+      files
+    })
+
+  }
+
+  @InputFiles
+  FileCollection getRequiredFiles() {
+    getFirstLevelFiles(require, 'required')
+  }
+
+  @InputFiles
+  FileCollection getAllowedToUseFiles() {
+    getFirstLevelFiles(allowedToUse, 'allowed to user')
+  }
+
+  @InputFiles
+  FileCollection getAllowedToDeclareFiles() {
+    getFirstLevelFiles(allowedToDeclare, 'allowed to declare')
+  }
+
+  private FileCollection getFirstLevelFiles(List<Configuration> configurations, String name) {
+    project.files({
+      def files = ProjectDependencyResolver.removeNulls(
+          ProjectDependencyResolver.getFirstLevelDependencies(
+              ProjectDependencyResolver.removeNulls(configurations)
+          )*.allModuleArtifacts*.file.flatten()
+      )
+      project.logger.info "First level $name files: $files"
+      files
+    })
   }
 }

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
@@ -5,6 +5,8 @@ import org.apache.maven.shared.dependency.analyzer.DefaultClassAnalyzer
 import org.apache.maven.shared.dependency.analyzer.DependencyAnalyzer
 import org.apache.maven.shared.dependency.analyzer.ProjectDependencyAnalysis
 import org.apache.maven.shared.dependency.analyzer.asm.ASMDependencyAnalyzer
+import org.gradle.api.Project
+import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
@@ -13,29 +15,38 @@ import org.gradle.api.logging.Logger
 import java.util.concurrent.ConcurrentHashMap
 
 class ProjectDependencyResolver {
-  private static final ConcurrentHashMap<File, Set<String>> ARTIFACT_CLASS_CACHE = new ConcurrentHashMap<>()
+  static final String CACHE_NAME = 'ca.cutterslade.gradle.analyze.ProjectDependencyResolver.artifactClassCache'
 
   private final ClassAnalyzer classAnalyzer = new DefaultClassAnalyzer()
   private final DependencyAnalyzer dependencyAnalyzer = new ASMDependencyAnalyzer()
 
+  private final Project project
+  private final ConcurrentHashMap<File, Set<String>> artifactClassCache
   private final Logger logger
   private final List<Configuration> require
   private final List<Configuration> allowedToUse
   private final List<Configuration> allowedToDeclare
   private final Iterable<File> classesDirs
 
-  ProjectDependencyResolver(final Logger logger, final List<Configuration> require,
+  ProjectDependencyResolver(final Project project, final List<Configuration> require,
       final List<Configuration> allowedToUse, final List<Configuration> allowedToDeclare,
       final Iterable<File> classesDirs) {
-    this.logger = logger
+    this.project = project
+    try {
+      this.artifactClassCache = project.rootProject.extensions.getByName(CACHE_NAME)
+    }
+    catch (UnknownDomainObjectException e) {
+      throw new IllegalStateException('Dependency analysis plugin must also be applied to the root project', e)
+    }
+    this.logger = project.logger
     this.require = removeNulls(require)
     this.allowedToUse = removeNulls(allowedToUse)
     this.allowedToDeclare = removeNulls(allowedToDeclare)
     this.classesDirs = classesDirs
   }
 
-  private static <T> List<T> removeNulls(final List<T> list) {
-    null == list ? [] : list - null
+  static <T, C extends Collection<T>> C removeNulls(final C collection) {
+    null == collection ? [] : collection - null
   }
 
   ProjectDependencyAnalysis analyzeDependencies() {
@@ -106,7 +117,7 @@ class ProjectDependencyResolver {
     getFirstLevelDependencies(allowedToDeclare)
   }
 
-  private Set<ResolvedDependency> getFirstLevelDependencies(final List<Configuration> configurations) {
+  static Set<ResolvedDependency> getFirstLevelDependencies(final List<Configuration> configurations) {
     configurations.collect {it.resolvedConfiguration.firstLevelModuleDependencies}.flatten()
   }
 
@@ -120,12 +131,20 @@ class ProjectDependencyResolver {
   private Map<File, Set<String>> buildArtifactClassMap(Set<File> dependencyArtifacts) throws IOException {
     final Map<File, Set<String>> artifactClassMap = [:]
 
+    int hits = 0
+    int misses = 0
     dependencyArtifacts.each {File file ->
       if (file.name.endsWith('jar')) {
-        def classes = ARTIFACT_CLASS_CACHE[file]
+        def classes = artifactClassCache[file]
         if (null == classes) {
+          logger.debug "Artifact class cache miss for $file"
+          misses++
           classes = classAnalyzer.analyze(file.toURI().toURL()).asImmutable()
-          ARTIFACT_CLASS_CACHE.putIfAbsent(file, classes)
+          artifactClassCache.putIfAbsent(file, classes)
+        }
+        else {
+          logger.debug "Artifact class cache hit for $file"
+          hits++
         }
         artifactClassMap.put(file, classes)
       }
@@ -133,6 +152,7 @@ class ProjectDependencyResolver {
         logger.info "Skipping analysis of file for classes: $file"
       }
     }
+    logger.info "Built artifact class map with $hits hits and $misses misses; cache size is ${artifactClassCache.size()}"
     return artifactClassMap
   }
 

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
@@ -20,7 +20,6 @@ class ProjectDependencyResolver {
   private final ClassAnalyzer classAnalyzer = new DefaultClassAnalyzer()
   private final DependencyAnalyzer dependencyAnalyzer = new ASMDependencyAnalyzer()
 
-  private final Project project
   private final ConcurrentHashMap<File, Set<String>> artifactClassCache
   private final Logger logger
   private final List<Configuration> require
@@ -31,7 +30,6 @@ class ProjectDependencyResolver {
   ProjectDependencyResolver(final Project project, final List<Configuration> require,
       final List<Configuration> allowedToUse, final List<Configuration> allowedToDeclare,
       final Iterable<File> classesDirs) {
-    this.project = project
     try {
       this.artifactClassCache = project.rootProject.extensions.getByName(CACHE_NAME)
     }


### PR DESCRIPTION
This required a handful of changes, and a minor compatibility breakage.

Compatibility breaking change: The plugin must now be applied to the root project of a multi-project build.

Other changes:
* Plugin now does not fail the build when applied to a project without the java plugin applied; it has no effect on projects without the java plugin applied.
* Plugin will cause the build to fail if it has been applied to a child project but not the parent project
* Plugin now produces an output file at `"$project.buildDir/dependency-analyze/result` containing exception message which caused to build to fail. This will be an empty file if no issues were found.
* Plugin can be considered up-to-date if no input/output changes have occurred.
* Plugin output can be cached in gradle versions which support task output caching.