### PR TITLE
Remove travis build with Java 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: groovy
 jdk:
-- openjdk6
 - oraclejdk7
 - openjdk7
 - oraclejdk8


### PR DESCRIPTION
The travis CI build with OpenJDK6 is failing to download the gradle dist. I plan on abandoning Java 6 soon anyway.