### PR TITLE
Apply tasks when 'java' is applied, not if.

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -12,7 +12,7 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
     if (project.rootProject == project) {
       project.rootProject.extensions.add(ProjectDependencyResolver.CACHE_NAME, new ConcurrentHashMap<>())
     }
-    if (project.plugins.hasPlugin('java')) {
+    project.plugins.withId('java') {
       project.configurations.create('permitUnusedDeclared')
       project.configurations.create('permitTestUnusedDeclared')
 


### PR DESCRIPTION
Currently this plugin does not work when you do:

```
apply plugin: 'ca.cutterslade.analyze'
apply plugin: 'java'
```

This fix will allow the above scenario to work just the same as:

```
apply plugin: 'java'
apply plugin: 'ca.cutterslade.analyze'
```