### PR TITLE
Maven dependency analyzer update to 1.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'org.apache.maven.shared:maven-dependency-analyzer:1.6'
+  compile 'org.apache.maven.shared:maven-dependency-analyzer:1.10'
 }
 
 sourceCompatibility = 1.6


### PR DESCRIPTION
This is a simple PR that updates the maven-dependency-analyzer to the latest version 1.10.