### PR TITLE
Maven dependency analyzer update to 1.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,11 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'org.apache.maven.shared:maven-dependency-analyzer:1.6'
+  compile 'org.apache.maven.shared:maven-dependency-analyzer:1.10'
 }
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 task sourcesJar(type: Jar, dependsOn: classes) {
   classifier = 'sources'
@@ -84,8 +84,8 @@ if (this.hasProperty('jfrogUser') && this.hasProperty('jfrogPassword')) {
 
 task javaVersionCheck() {
   doLast {
-    if (JavaVersion.current() != JavaVersion.VERSION_1_6) {
-      throw new GradleException('Build must be run on Java 6')
+    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+      throw new GradleException('Build must be run on Java 8')
     }
   }
 }


### PR DESCRIPTION
This PR updates the maven-dependency-analyzer to 1.10. It requires a newer version of Java (I have tested against 1.8) otherwise it fails on java class compiled error. 

Was there any specific reason to remain on 1.6 for this project? 