### PR TITLE
Upgrade dependency analyzer to 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,58 +3,15 @@ workflows:
   version: 2
   java_versions:
     jobs:
-    - build-6
-    - build-7
     - build-8
+    - build-9
+    - build-10
+    - build-11
 
 jobs:
-  build-6:
-    docker:
-    - image: openjdk:6-jdk
-    working_directory: ~/repo
-
-    environment:
-      JVM_OPTS: -Xmx3200m
-      TERM: dumb
-    
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - v1-dependencies-{{ checksum "build.gradle" }}
-        - v1-dependencies-
-    - run: ./gradlew dependencies
-    - save_cache:
-        paths:
-        - ~/.gradle
-        key: v1-dependencies-{{ checksum "build.gradle" }}
-    - run: ./gradlew test
-
-  build-7:
-    docker:
-    - image: openjdk:7u121-jdk
-    working_directory: ~/repo
-
-    environment:
-      JVM_OPTS: -Xmx3200m
-      TERM: dumb
-
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - v1-dependencies-{{ checksum "build.gradle" }}
-        - v1-dependencies-
-    - run: ./gradlew dependencies
-    - save_cache:
-        paths:
-        - ~/.gradle
-        key: v1-dependencies-{{ checksum "build.gradle" }}
-    - run: ./gradlew test
-
   build-8:
     docker:
-    - image: openjdk:8-jdk
+    - image: adoptopenjdk/openjdk8
     working_directory: ~/repo
 
     environment:
@@ -74,26 +31,69 @@ jobs:
         key: v1-dependencies-{{ checksum "build.gradle" }}
     - run: ./gradlew test
 
-# Gradle 2.14 does not run on Java 9, and that's OK
-#  build-9:
-#    docker:
-#    - image: circleci/openjdk:9-jdk
-#    working_directory: ~/repo
-#
-#    environment:
-#      JVM_OPTS: -Xmx3200m
-#      TERM: dumb
-#
-#    steps:
-#    - checkout
-#    - restore_cache:
-#        keys:
-#        - v1-dependencies-{{ checksum "build.gradle" }}
-#        - v1-dependencies-
-#    - run: gradle dependencies
-#    - save_cache:
-#        paths:
-#        - ~/.gradle
-#        key: v1-dependencies-{{ checksum "build.gradle" }}
-#    - run: ./gradlew test
-#
+  build-9:
+    docker:
+    - image: adoptopenjdk/openjdk9
+    working_directory: ~/repo
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ checksum "build.gradle" }}
+        - v1-dependencies-
+    - run: ./gradlew dependencies
+    - save_cache:
+        paths:
+        - ~/.gradle
+        key: v1-dependencies-{{ checksum "build.gradle" }}
+    - run: ./gradlew test
+
+  build-10:
+    docker:
+    - image: adoptopenjdk/openjdk10
+    working_directory: ~/repo
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ checksum "build.gradle" }}
+        - v1-dependencies-
+    - run: ./gradlew dependencies
+    - save_cache:
+        paths:
+        - ~/.gradle
+        key: v1-dependencies-{{ checksum "build.gradle" }}
+    - run: ./gradlew test
+
+  build-11:
+    docker:
+    - image: adoptopenjdk/openjdk11
+    working_directory: ~/repo
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ checksum "build.gradle" }}
+        - v1-dependencies-
+    - run: ./gradlew dependencies
+    - save_cache:
+        paths:
+        - ~/.gradle
+        key: v1-dependencies-{{ checksum "build.gradle" }}
+    - run: ./gradlew test
+

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ task analyzeJavaLibraryTestDependencies(type: AnalyzeDependenciesTask) {
 
 For more practical examples, see the [plugin source](https://github.com/wfhartford/gradle-dependency-analyze/blob/master/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy).
 
+# Version 1.3
+Version 1.3 of this plugin does not introduce any significant functional changes, but adds support for Java version 9, 10, and 11, while dropping support for Java versions 6 and 7.
+
 # Version 1.2
 Version 1.2 of this plugin introduces a couple significant changes.
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,11 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'org.apache.maven.shared:maven-dependency-analyzer:1.6'
+  compile 'org.apache.maven.shared:maven-dependency-analyzer:1.10'
 }
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 task sourcesJar(type: Jar, dependsOn: classes) {
   classifier = 'sources'
@@ -84,8 +84,8 @@ if (this.hasProperty('jfrogUser') && this.hasProperty('jfrogPassword')) {
 
 task javaVersionCheck() {
   doLast {
-    if (JavaVersion.current() != JavaVersion.VERSION_1_6) {
-      throw new GradleException('Build must be run on Java 6')
+    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+      throw new GradleException('Build must be run on Java 8')
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'ca.cutterslade.gradle'
-version = '1.2.3-SNAPSHOT'
+version = '1.3.0-SNAPSHOT'
 
 repositories {
   jcenter()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip


### PR DESCRIPTION
Bumps minimum Java version to 8; adds support for 9, 10, 11.