### PR TITLE
Use complete artifact toString in output

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -46,7 +46,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
       if (violations) {
         buffer.append("$section: \n")
         violations*.moduleVersion*.id.each {
-          buffer.append(" - $it.group:$it.name:$it.version\n")
+          buffer.append(" - $it\n")
         }
       }
     }


### PR DESCRIPTION
Use the toString() method on the artifact in error report so that classifier and type will be included where appropraite.