### PR TITLE
Make tasks depend on appropriate configuration

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -20,7 +20,7 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
       project.configurations.create('permitTestUsedUndeclared')
 
       def mainTask = project.task('analyzeClassesDependencies',
-          dependsOn: 'classes',
+          dependsOn: ['classes', project.configurations.compile],
           type: AnalyzeDependenciesTask,
           group: 'Verification',
           description: 'Analyze project for dependency issues related to main source set.'
@@ -41,7 +41,7 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
       }
 
       def testTask = project.task('analyzeTestClassesDependencies',
-          dependsOn: 'testClasses',
+          dependsOn: ['testClasses', project.configurations.testCompile],
           type: AnalyzeDependenciesTask,
           group: 'Verification',
           description: 'Analyze project for dependency issues related to test source set.'


### PR DESCRIPTION
In certain circumstances involving multi project builds, the analyze tasks would run before JARs which it requires are built. Adding a dependency on the compile configuration to the `analyzeClassesDependencies` task (and similar for test task) resolves this situation.