### PR TITLE
feat(gradle-dependency-analyze): added resolvable gradle configurations to root

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -28,7 +28,9 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
         require = [
             project.configurations.compile,
             project.configurations.findByName('compileOnly'),
-            project.configurations.findByName('provided')
+            project.configurations.findByName('provided'),
+            project.configurations.findByName('compileClasspath'),
+            project.configurations.findByName('runtimeClasspath')
         ]
         allowedToUse = [
             project.configurations.permitUsedUndeclared

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -29,8 +29,7 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
             project.configurations.compile,
             project.configurations.findByName('compileOnly'),
             project.configurations.findByName('provided'),
-            project.configurations.findByName('compileClasspath'),
-            project.configurations.findByName('runtimeClasspath')
+            project.configurations.findByName('compileClasspath')
         ]
         allowedToUse = [
             project.configurations.permitUsedUndeclared
@@ -51,8 +50,7 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
         require = [
             project.configurations.testCompile,
             project.configurations.findByName('testCompileOnly'),
-            project.configurations.findByName('testCompileClasspath'),
-            project.configurations.findByName('testRuntimeClasspath')
+            project.configurations.findByName('testCompileClasspath')
         ]
         allowedToUse = [
             project.configurations.compile,

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -48,12 +48,16 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
       ) {
         require = [
             project.configurations.testCompile,
-            project.configurations.findByName('testCompileOnly')
+            project.configurations.findByName('testCompileOnly'),
+            project.configurations.findByName('testCompileClasspath'),
+            project.configurations.findByName('testRuntimeClasspath')
         ]
         allowedToUse = [
             project.configurations.compile,
             project.configurations.permitTestUsedUndeclared,
-            project.configurations.findByName('provided')
+            project.configurations.findByName('provided'),
+            project.configurations.findByName('compileClasspath'),
+            project.configurations.findByName('runtimeClasspath')
         ]
         allowedToDeclare = [
             project.configurations.permitTestUnusedDeclared


### PR DESCRIPTION
Adding support for gradle 5 configurations used to declare dependencies.

According to gradle documentation https://docs.gradle.org/current/userguide/java_library_plugin.html , 
base gradle tasks like implementation, testImplementation and etc. inherited from configuration compileClasspath, runtimeClasspath, testCompileClasspath & testRuntimeClasspath.

![alt text](https://docs.gradle.org/current/userguide/img/java-library-ignore-deprecated-main.png)
![alt text](https://docs.gradle.org/current/userguide/img/java-library-ignore-deprecated-test.png)

So we should look for dependencies at gradle root configurations(compileClasspath, runtimeClasspath, testCompileClasspath & testRuntimeClasspath).
It should fix issues: https://github.com/wfhartford/gradle-dependency-analyze/issues/90 https://github.com/wfhartford/gradle-dependency-analyze/issues/39