### PR TITLE
#100: Missing support for multi-project dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,17 @@ if (this.hasProperty('jfrogUser') && this.hasProperty('jfrogPassword')) {
   }
 }
 
+task javaVersionCheck() {
+  doLast {
+    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+      throw new GradleException('Build must be run on Java 8')
+    }
+  }
+}
+
 tasks.withType(PublishToMavenRepository) {
   it.dependsOn check
+  it.dependsOn javaVersionCheck
 }
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -89,17 +89,8 @@ if (this.hasProperty('jfrogUser') && this.hasProperty('jfrogPassword')) {
   }
 }
 
-task javaVersionCheck() {
-  doLast {
-    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-      throw new GradleException('Build must be run on Java 8')
-    }
-  }
-}
-
 tasks.withType(PublishToMavenRepository) {
   it.dependsOn check
-  it.dependsOn javaVersionCheck
 }
 
 gradlePlugin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-bin.zip

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -15,8 +15,11 @@ import java.lang.reflect.Method
 class AnalyzeDependenciesTask extends DefaultTask {
   @Input
   boolean justWarn = false
+  @InputFiles
   List<Configuration> require = []
+  @InputFiles
   List<Configuration> allowedToUse = []
+  @InputFiles
   List<Configuration> allowedToDeclare = []
   @InputFiles
   FileCollection classesDirs = project.files()

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
@@ -146,23 +146,18 @@ class ProjectDependencyResolver {
     int hits = 0
     int misses = 0
     dependencyArtifacts.each {File file ->
-      if (file.name.endsWith('jar')) {
-        def classes = artifactClassCache[file]
-        if (null == classes) {
-          logger.debug "Artifact class cache miss for $file"
-          misses++
-          classes = classAnalyzer.analyze(file.toURI().toURL()).asImmutable()
-          artifactClassCache.putIfAbsent(file, classes)
-        }
-        else {
-          logger.debug "Artifact class cache hit for $file"
-          hits++
-        }
-        artifactClassMap.put(file, classes)
+      def classes = artifactClassCache[file]
+      if (null == classes) {
+        logger.debug "Artifact class cache miss for $file"
+        misses++
+        classes = classAnalyzer.analyze(file.toURI().toURL()).asImmutable()
+        artifactClassCache.putIfAbsent(file, classes)
       }
       else {
-        logger.info "Skipping analysis of file for classes: $file"
+        logger.debug "Artifact class cache hit for $file"
+        hits++
       }
+      artifactClassMap.put(file, classes)
     }
     logger.info "Built artifact class map with $hits hits and $misses misses; cache size is ${artifactClassCache.size()}"
     return artifactClassMap


### PR DESCRIPTION
I don't know the reason for removing the analysis from artefacts which are not JAR files. I have removed it and it worked like a charm. I have also switched to a more recent version of Gradle as for me the build is working fine. 

Concerning the removal of the check of Java8, I could revert it if you can explain to me why it was introduced? I am building with Java11 with no issues.