### PR TITLE
Use resolvable configurations only

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -20,16 +20,13 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
       project.configurations.create('permitTestUsedUndeclared')
 
       def mainTask = project.task('analyzeClassesDependencies',
-          dependsOn: ['classes', project.configurations.compile],
+          dependsOn: ['classes', project.configurations.compileClasspath],
           type: AnalyzeDependenciesTask,
           group: 'Verification',
           description: 'Analyze project for dependency issues related to main source set.'
       ) {
         require = [
-            project.configurations.compile,
-            project.configurations.findByName('compileOnly'),
-            project.configurations.findByName('provided'),
-            project.configurations.findByName('compileClasspath')
+            project.configurations.compileClasspath
         ]
         allowedToUse = [
             project.configurations.permitUsedUndeclared
@@ -42,22 +39,17 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
       }
 
       def testTask = project.task('analyzeTestClassesDependencies',
-          dependsOn: ['testClasses', project.configurations.testCompile],
+          dependsOn: ['testClasses', project.configurations.testCompileClasspath],
           type: AnalyzeDependenciesTask,
           group: 'Verification',
           description: 'Analyze project for dependency issues related to test source set.'
       ) {
         require = [
-            project.configurations.testCompile,
-            project.configurations.findByName('testCompileOnly'),
-            project.configurations.findByName('testCompileClasspath')
+            project.configurations.testCompileClasspath
         ]
         allowedToUse = [
-            project.configurations.compile,
             project.configurations.permitTestUsedUndeclared,
-            project.configurations.findByName('provided'),
-            project.configurations.findByName('compileClasspath'),
-            project.configurations.findByName('runtimeClasspath')
+            project.configurations.compileClasspath
         ]
         allowedToDeclare = [
             project.configurations.permitTestUnusedDeclared


### PR DESCRIPTION
`compileClasspath` was introduced in gradle 3.0; it contains all dependencies and constraints defined in `compile`, `api`, `implementation` and `compileOnly`. With that in mind, references to `compile` and `compileOnly` can be freely removed because they are already contained in `compileClasspath`.
The proposed patch removes all references to `provided` configuration; it was never mentioned in gradle documentation, and I believe it's an artifact that was inadvertently ported from maven plugin.
I also removed references to `runtimeClasspath`. Dependencies declared with `runtimeClasspath` are not automatically available during test compilation, so I think this change is justified. 

Fixes #99 
Fixes #109 
Replaces #112, which did not fix handling of references declared with `compile`
Does not help with #108, which requires applying constraints from `compileClasspath` to `permitXXX` configurations