### PR TITLE
allow defining aggregator dependencies

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -15,6 +15,8 @@ import java.lang.reflect.Method
 class AnalyzeDependenciesTask extends DefaultTask {
   @Input
   boolean justWarn = false
+  @Input
+  List<String> aggregators = []
   @InputFiles
   List<Configuration> require = []
   @InputFiles
@@ -42,7 +44,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
     logger.info "Analyzing dependencies of $classesDirs for [require: $require, allowedToUse: $allowedToUse, " +
         "allowedToDeclare: $allowedToDeclare]"
     ProjectDependencyAnalysis analysis =
-        new ProjectDependencyResolver(project, require, allowedToUse, allowedToDeclare, classesDirs)
+        new ProjectDependencyResolver(project, require, allowedToUse, allowedToDeclare, classesDirs, aggregators)
             .analyzeDependencies()
     StringBuffer buffer = new StringBuffer()
     ['usedUndeclaredArtifacts', 'unusedDeclaredArtifacts'].each {section ->

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
@@ -29,10 +29,11 @@ class ProjectDependencyResolver {
   private final List<Configuration> allowedToUse
   private final List<Configuration> allowedToDeclare
   private final Iterable<File> classesDirs
+  private final Map<ResolvedArtifact, Set<ResolvedArtifact>> aggregatorsWithDependencies = [:]
 
   ProjectDependencyResolver(final Project project, final List<Configuration> require,
       final List<Configuration> allowedToUse, final List<Configuration> allowedToDeclare,
-      final Iterable<File> classesDirs) {
+      final Iterable<File> classesDirs, List<String> aggregators) {
     try {
       this.artifactClassCache =
           project.rootProject.extensions.getByName(CACHE_NAME) as ConcurrentHashMap<File, Set<String>>
@@ -45,6 +46,13 @@ class ProjectDependencyResolver {
     this.allowedToUse = removeNulls(allowedToUse) as List
     this.allowedToDeclare = removeNulls(allowedToDeclare) as List
     this.classesDirs = classesDirs
+
+    for (String aggregator : aggregators) {
+      def artifacts = resolveArtifacts([project.getConfigurations().detachedConfiguration(project.dependencies.create(aggregator))])
+      def key = artifacts.find {it.id.componentIdentifier.displayName == aggregator}
+      aggregatorsWithDependencies.put(key, artifacts)
+      logger.info(artifacts.toString())
+    }
   }
 
   static <T> Collection<T> removeNulls(final Collection<T> collection) {
@@ -94,11 +102,7 @@ class ProjectDependencyResolver {
         flatten() as Set<ResolvedArtifact>
     logger.info "allowedToDeclareArtifacts = $allowedToDeclareArtifacts"
 
-    Set<ResolvedArtifact> allArtifacts = (((require
-        .collect {it.resolvedConfiguration}
-        .collect {it.firstLevelModuleDependencies}.flatten()) as Set<ResolvedDependency>)
-        .collect {it.allModuleArtifacts}.flatten()) as Set<ResolvedArtifact>
-
+    Set<ResolvedArtifact> allArtifacts = resolveArtifacts(require)
     logger.info "allArtifacts = $allArtifacts"
 
     def usedDeclared = allArtifacts.findAll {ResolvedArtifact artifact -> artifact.file in usedDeclaredArtifacts}
@@ -109,6 +113,20 @@ class ProjectDependencyResolver {
     def unusedDeclared = allArtifacts.findAll {ResolvedArtifact artifact -> artifact.file in unusedDeclaredArtifacts}
     if (allowedToDeclareArtifacts) {
       unusedDeclared -= allowedToDeclareArtifacts
+    }
+
+    def aggregatorUsage = used(usedArtifacts, aggregatorsWithDependencies).groupBy {it.value.size() > 0}
+    if (aggregatorUsage.containsKey(false)) {
+      unusedDeclared += aggregatorUsage.get(false).keySet()
+    }
+    if (aggregatorUsage.containsKey(true)) {
+      def usedAggregator = aggregatorUsage.get(true)
+      def usedAggregatorDependencies = usedAggregator.keySet()
+      usedDeclared += usedAggregatorDependencies
+      unusedDeclared -= usedAggregatorDependencies
+      def flatten = usedAggregator.values().flatten().collect({ it -> (ResolvedArtifact)it})
+      unusedDeclared += usedDeclared.intersect(flatten)
+      usedUndeclared -= usedAggregatorDependencies.collect {aggregatorsWithDependencies.get(it)}.flatten()
     }
 
     return new ProjectDependencyAnalysis(
@@ -202,5 +220,25 @@ class ProjectDependencyResolver {
       }
     }
     return usedArtifacts
+  }
+
+  private Set<ResolvedArtifact> resolveArtifacts(List<Configuration> configurations) {
+    Set<ResolvedArtifact> allArtifacts = (((configurations
+            .collect { it.resolvedConfiguration }
+            .collect { it.firstLevelModuleDependencies }.flatten()) as Set<ResolvedDependency>)
+            .collect { it.allModuleArtifacts }.flatten()) as Set<ResolvedArtifact>
+    allArtifacts
+  }
+
+  private Map<ResolvedArtifact, Collection<ResolvedArtifact>> used(Set<File> files, Map<ResolvedArtifact, Set<ResolvedArtifact>> stringSetMap) {
+    def map = new HashMap<ResolvedArtifact, Collection<ResolvedArtifact>>()
+
+    stringSetMap.each {it ->
+      def filesForAggregator = it.value.collect({ it.file })
+      def disjoint = filesForAggregator.intersect(files)
+      map.put(it.key, it.value.findAll {disjoint.contains(it.file)})
+    }
+
+    return map
   }
 }

--- a/src/test/groovy/ca.cutterslade.gradle.analyze/GradleProject.groovy
+++ b/src/test/groovy/ca.cutterslade.gradle.analyze/GradleProject.groovy
@@ -10,6 +10,8 @@ class GradleProject {
     Set<GroovyClass> testClasses = []
     Set<String> plugins = ['groovy']
     Set<GradleDependency> dependencies = []
+    String repositories;
+    Set<String> aggregators = []
 
     GradleProject(String name, boolean rootProject = false) {
         this.name = name
@@ -88,7 +90,14 @@ class GradleProject {
             }
             buildGradle += "}\n"
         }
-
+        buildGradle += repositories ?: ''
+        if (!aggregators.isEmpty()) {
+            buildGradle += "analyzeClassesDependencies {\n"
+            buildGradle += "  aggregators = [\n"
+            buildGradle += aggregators.collect {"    '${it}'"}.join(',\n')
+            buildGradle += "  ]\n"
+            buildGradle += "}\n"
+        }
         if (!dependencies.isEmpty()) {
             buildGradle += "dependencies {\n"
             for (def dep : dependencies) {
@@ -98,5 +107,18 @@ class GradleProject {
         }
 
         new File(root, "build.gradle").text = buildGradle
+    }
+
+    def withMavenRepositories() {
+        repositories = "repositories {\n" +
+                "    mavenLocal()\n" +
+                "    mavenCentral()\n" +
+                "}\n"
+        this
+    }
+
+    def withAggregator(String aggregator) {
+        aggregators.add(aggregator)
+        this
     }
 }

--- a/src/test/groovy/ca.cutterslade.gradle.analyze/GroovyClass.groovy
+++ b/src/test/groovy/ca.cutterslade.gradle.analyze/GroovyClass.groovy
@@ -16,7 +16,8 @@ class GroovyClass {
     private def buildUsedClasses() {
         def out = ""
         for (String clazz : usedClasses) {
-            out += "  ${clazz} ${clazz}\n"
+            def var = clazz.contains('.') ? clazz.substring(clazz.lastIndexOf('.') + 1) : clazz
+            out += "  ${clazz} _${var.toLowerCase()}\n"
         }
         out
     }


### PR DESCRIPTION
an idea to address issue #122 

by defining a list of aggregator dependencies for the task the following will now happen

when an aggregator dependency includes a previously used but undeclared dependency it will be removed from the used and undeclared list and also added to the used declared list
when an aggregator dependency does not contain any dependencies that are used it will be added to the unused declared dependency list

in that way, it Is possible to define something like a spring-starter dependency as an aggregator dependency which will be used to "clean up" the result

Closes #122